### PR TITLE
:recycle: clearsky: Robuster time interpolation

### DIFF
--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -182,14 +182,9 @@ def lookup_linke_turbidity(time, lats_1d, lons_1d, grid=False, filepath=None,
     # daynumber for every 15-th day of the month; including a leading dec and trailing jan
     daynumber = get_daynumber(time)
 
-    if time.day <= 15:
-        first_index = time.month - 1
-    else:
-        first_index = time.month
-
     linke_time_interpolation_function = interpolate.interp1d(
-        daynumber[first_index:first_index + 2],
-        linke_turbidity_data[:, :, first_index:first_index + 2] / 20
+        daynumber,
+        linke_turbidity_data[:, :, :] / 20,
     )
 
     linke_turbidity_interpolator = interpolate.RectBivariateSpline(

--- a/pvlib/clearsky.py
+++ b/pvlib/clearsky.py
@@ -184,7 +184,7 @@ def lookup_linke_turbidity(time, lats_1d, lons_1d, grid=False, filepath=None,
 
     linke_time_interpolation_function = interpolate.interp1d(
         daynumber,
-        linke_turbidity_data[:, :, :] / 20,
+        linke_turbidity_data / 20,
     )
 
     linke_turbidity_interpolator = interpolate.RectBivariateSpline(


### PR DESCRIPTION
Rationale:
The old method led to python exceptions in case of leap years
